### PR TITLE
Makefile: add bdw-gc when linking so linker is not confused

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ bdw-%-gc.o: bdw.c %-embedder.h %.c
 bdw-%.o: bdw.c %.c
 	$(COMPILE) -DGC_CONSERVATIVE_ROOTS=1 -DGC_CONSERVATIVE_TRACE=1 -include bdw-attrs.h -o $@ -c $*.c
 bdw-%: bdw-%.o bdw-%-gc.o gc-stack.o gc-platform.o
-	$(CC) $(LDFLAGS) `pkg-config --libs bdw-gc` -o $@ $^
+	$(CC) $(LDFLAGS) -o $@ $^ `pkg-config --libs bdw-gc`
 
 semi-%-gc.o: semi.c %-embedder.h large-object-space.h assert.h debug.h %.c
 	$(COMPILE) -DGC_PRECISE_ROOTS=1 -include $*-embedder.h -o $@ -c semi.c


### PR DESCRIPTION
With the previous Makefile I'd run into compilation errors:

    φ make
    gcc -Wall -O2 -g -flto -fno-strict-aliasing -fvisibility=hidden -Wno-unused -DNDEBUG -I. -o gc-stack.o -c gc-stack.c
    gcc -Wall -O2 -g -flto -fno-strict-aliasing -fvisibility=hidden -Wno-unused -DNDEBUG -I. -o gc-platform.o -c gc-platform-gnu-linux.c
    gcc -Wall -O2 -g -flto -fno-strict-aliasing -fvisibility=hidden -Wno-unused -DNDEBUG -I. -DGC_CONSERVATIVE_ROOTS=1 -DGC_CONSERVATIVE_TRACE=1 -include bdw-attrs.h -o bdw-quads.o -c quads.c
    gcc -Wall -O2 -g -flto -fno-strict-aliasing -fvisibility=hidden -Wno-unused -DNDEBUG -I. -DGC_CONSERVATIVE_ROOTS=1 -DGC_CONSERVATIVE_TRACE=1 `pkg-config --cflags bdw-gc` -include quads-embedder.h -o bdw-quads-gc.o -c bdw.c
    gcc -lpthread -flto `pkg-config --libs bdw-gc` -o bdw-quads bdw-quads.o bdw-quads-gc.o gc-stack.o gc-platform.o
    /usr/bin/ld: /tmp/ccizVWpr.ltrans0.ltrans.o: in function `allocate_small_slow.constprop.0':
    /home/mrnugget/code/clones/whippet-gc/bdw.c:78: undefined reference to `GC_generic_malloc_many'
    /usr/bin/ld: /home/mrnugget/code/clones/whippet-gc/bdw.c:81: undefined reference to `GC_get_heap_size'
    /usr/bin/ld: /tmp/ccizVWpr.ltrans0.ltrans.o: in function `main':
    /home/mrnugget/code/clones/whippet-gc/bdw.c:213: undefined reference to `GC_set_max_heap_size'
    /usr/bin/ld: /tmp/ccizVWpr.ltrans0.ltrans.o:/home/mrnugget/code/clones/whippet-gc/bdw.c:219: undefined reference to `GC_init'
    /usr/bin/ld: /tmp/ccizVWpr.ltrans0.ltrans.o:/home/mrnugget/code/clones/whippet-gc/bdw.c:220: undefined reference to `GC_get_heap_size'
    /usr/bin/ld: /tmp/ccizVWpr.ltrans0.ltrans.o:/home/mrnugget/code/clones/whippet-gc/bdw.c:223: undefined reference to `GC_allow_register_threads'
    /usr/bin/ld: /tmp/ccizVWpr.ltrans0.ltrans.o:/home/mrnugget/code/clones/whippet-gc/bdw.c:224: undefined reference to `GC_malloc'
    /usr/bin/ld: /tmp/ccizVWpr.ltrans0.ltrans.o: in function `main':
    /home/mrnugget/code/clones/whippet-gc/bdw.c:124: undefined reference to `GC_malloc'
    /usr/bin/ld: /home/mrnugget/code/clones/whippet-gc/bdw.c:260: undefined reference to `GC_get_gc_no'
    /usr/bin/ld: /tmp/ccizVWpr.ltrans0.ltrans.o:/home/mrnugget/code/clones/whippet-gc/bdw.c:261: undefined reference to `GC_get_heap_size'
    /usr/bin/ld: /tmp/ccizVWpr.ltrans0.ltrans.o:/home/mrnugget/code/clones/whippet-gc/bdw.c:222: undefined reference to `GC_expand_hp'
    collect2: error: ld returned 1 exit status
    make: *** [Makefile:44: bdw-quads] Error 1
    rm bdw-quads-gc.o bdw-quads.o

I think the [trick is](https://stackoverflow.com/questions/1517138/trying-to-include-a-library-but-keep-getting-undefined-reference-to-messages) to put the library last so the linker doesn't get confused.

That works for me, at least, and compilation now works.

Ignore if this is not valuable.